### PR TITLE
Tomo

### DIFF
--- a/app/controllers/admins/homes_controller.rb
+++ b/app/controllers/admins/homes_controller.rb
@@ -1,2 +1,6 @@
 class Admins::HomesController < ApplicationController
+
+  def top
+  end
+
 end

--- a/app/controllers/admins/homes_controller.rb
+++ b/app/controllers/admins/homes_controller.rb
@@ -1,6 +1,2 @@
 class Admins::HomesController < ApplicationController
-
-  def top
-  end
-
 end

--- a/app/views/admins/sessions/new.html.erb
+++ b/app/views/admins/sessions/new.html.erb
@@ -11,13 +11,6 @@
     <%= f.password_field :password, autocomplete: "current-password" %>
   </div>
 
-  <!--<%# if devise_mapping.rememberable? %>-->
-  <!--  <div class="field">-->
-  <!--    <%= f.check_box :remember_me %>-->
-  <!--    <%= f.label :remember_me %>-->
-  <!--  </div>-->
-  <!--<%# end %>-->
-
   <div class="actions">
     <%= f.submit "ログイン" %>
   </div>

--- a/app/views/admins/sessions/new.html.erb
+++ b/app/views/admins/sessions/new.html.erb
@@ -1,26 +1,26 @@
-<h2>Log in</h2>
+<h2>管理者ログイン</h2>
 
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="field">
-    <%= f.label :email %><br />
+    <%= f.label :メールアドレス %>
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>
 
   <div class="field">
-    <%= f.label :password %><br />
+    <%= f.label :パスワード %>
     <%= f.password_field :password, autocomplete: "current-password" %>
   </div>
 
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
-    </div>
-  <% end %>
+  <!--<%# if devise_mapping.rememberable? %>-->
+  <!--  <div class="field">-->
+  <!--    <%= f.check_box :remember_me %>-->
+  <!--    <%= f.label :remember_me %>-->
+  <!--  </div>-->
+  <!--<%# end %>-->
 
   <div class="actions">
-    <%= f.submit "Log in" %>
+    <%= f.submit "ログイン" %>
   </div>
 <% end %>
 
-<%= render "devise/shared/links" %>
+<%#= render "devise/shared/links" %>

--- a/app/views/public/sessions/new.html.erb
+++ b/app/views/public/sessions/new.html.erb
@@ -11,13 +11,6 @@
     <%= f.password_field :password, autocomplete: "current-password" %>
   </div>
 
-  <!--<%# if devise_mapping.rememberable? %>-->
-  <!--  <div class="field">-->
-  <!--    <%= f.check_box :remember_me %>-->
-  <!--    <%= f.label :remember_me %>-->
-  <!--  </div>-->
-  <!--<%# end %>-->
-
   <div class="actions">
     <%= f.submit "ログイン" %>
   </div>

--- a/app/views/public/sessions/new.html.erb
+++ b/app/views/public/sessions/new.html.erb
@@ -1,26 +1,30 @@
-<h2>Log in</h2>
-
+<h2>ログイン</h2>
+<h3>会員の方はこちらからログイン</h3>
 <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
   <div class="field">
-    <%= f.label :email %><br />
+    <%= f.label :メールアドレス %>
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>
 
   <div class="field">
-    <%= f.label :password %><br />
+    <%= f.label :パスワード %>
     <%= f.password_field :password, autocomplete: "current-password" %>
   </div>
 
-  <% if devise_mapping.rememberable? %>
-    <div class="field">
-      <%= f.check_box :remember_me %>
-      <%= f.label :remember_me %>
-    </div>
-  <% end %>
+  <!--<%# if devise_mapping.rememberable? %>-->
+  <!--  <div class="field">-->
+  <!--    <%= f.check_box :remember_me %>-->
+  <!--    <%= f.label :remember_me %>-->
+  <!--  </div>-->
+  <!--<%# end %>-->
 
   <div class="actions">
-    <%= f.submit "Log in" %>
+    <%= f.submit "ログイン" %>
   </div>
 <% end %>
 
-<%= render "devise/shared/links" %>
+<h3>会員登録がお済みでない方</h3>
+<%= link_to 'こちら', new_customer_registration_path %>
+から新規登録を行なって下さい。
+
+<%#= render "devise/shared/links" %>


### PR DESCRIPTION
ログイン画面の作成（顧客側、管理者側の両方）
デフォルトの部分テンプレートは使わずに、顧客側でサインアップ未済の場合の新規会員登録画面への遷移はlink_toにて作成しております。